### PR TITLE
Suggestion: permit multi-character "chrome" (i.e. terminators and separators)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,14 @@
 version = 3
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "slicedisplay"
 version = "0.2.2"
+dependencies = [
+ "cfg-if",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/vrmiguel/slicedisplay"
 repository = "https://github.com/vrmiguel/slicedisplay"
 
 [dependencies]
+cfg-if = "1.0.0"
 
 [features]
 multichar = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,6 @@ homepage = "https://github.com/vrmiguel/slicedisplay"
 repository = "https://github.com/vrmiguel/slicedisplay"
 
 [dependencies]
-  
+
+[features]
+multichar-chrome = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ repository = "https://github.com/vrmiguel/slicedisplay"
 [dependencies]
 
 [features]
-multichar-chrome = []
+multichar = []

--- a/README.md
+++ b/README.md
@@ -23,35 +23,54 @@ assert_eq!(numbers.display().to_string(), "[1, 2, 3, 4, 5]");
 
 It's also possible to slightly customize the display.
 
+```rust
+use slicedisplay::SliceDisplay;
+
+let hello: Vec<_> = "Hello".chars().collect();
+
+#[cfg(not(feature = "multichar"))]
+{
+    assert_eq!(
+        hello.display().delimiter(';').to_string(),
+        "[H; e; l; l; o]"
+    );
+    assert_eq!(
+        hello.display().terminator('{', '}').to_string(),
+        "{H, e, l, l, o}"
+    );
+    assert_eq!(
+        hello
+            .display()
+            .terminator('(', ')')
+            .delimiter(';')
+            .to_string(),
+        "(H; e; l; l; o)"
+    );
+
+    assert_eq!(
+        hello
+            .display()
+            .terminator('(', ')')
+            .delimiter(';')
+            .should_space(false)
+            .to_string(),
+        "(H;e;l;l;o)"
+    );
+}
+```
+
+Or, with the `multichar` feature, you can use mulitple characters:
 
 ```rust
 use slicedisplay::SliceDisplay;
 
 let hello: Vec<_> = "Hello".chars().collect();
-assert_eq!(
-    hello.display().delimiter(';').to_string(),
-    "[H; e; l; l; o]"
-);
-assert_eq!(
-    hello.display().terminator('{', '}').to_string(),
-    "{H, e, l, l, o}"
-);
-assert_eq!(
-    hello
-        .display()
-        .terminator('(', ')')
-        .delimiter(';')
-        .to_string(),
-    "(H; e; l; l; o)"
-);
 
-assert_eq!(
-    hello
-        .display()
-        .terminator('(', ')')
-        .delimiter(';')
-        .should_space(false)
-        .to_string(),
-    "(H;e;l;l;o)"
-);
+#[cfg(feature = "multichar")]
+{
+    assert_eq!(
+        hello.display().terminator("{{", "}}").delimiter(";;").to_string(),
+        "{{H;; e;; l;; l;; o}}"
+    );
+}
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use core::fmt::Display;
-#[cfg(not(feature = "multichar-chrome"))]
+#[cfg(not(feature = "multichar"))]
 use core::fmt::Write;
 
 /// Configurable Display implementation for slices and Vecs.
@@ -13,10 +13,10 @@ pub trait SliceDisplay<'a, T: Display> {
     fn display(&'a self) -> SliceDisplayImpl<'a, T>;
 }
 
-#[cfg(feature = "multichar-chrome")]
+#[cfg(feature = "multichar")]
 type ChromeLiteral = &'static str;
 
-#[cfg(not(feature = "multichar-chrome"))]
+#[cfg(not(feature = "multichar"))]
 type ChromeLiteral = char;
 
 /// Helper struct for printing Vecs and slices.
@@ -38,7 +38,7 @@ impl<'a, T: Display> SliceDisplayImpl<'a, T> {
     ///
     /// let hello: Vec<_> = "Hello".chars().collect();
     ///
-    /// #[cfg(not(feature = "multichar-chrome"))]
+    /// #[cfg(not(feature = "multichar"))]
     /// assert_eq!(hello.display().terminator('{', '}').to_string(), "{H, e, l, l, o}");
     /// ```
     pub fn terminator(self, beginning: ChromeLiteral, ending: ChromeLiteral) -> Self {
@@ -57,7 +57,7 @@ impl<'a, T: Display> SliceDisplayImpl<'a, T> {
     ///
     /// let hello: Vec<_> = "Hello".chars().collect();
     ///
-    /// #[cfg(not(feature = "multichar-chrome"))]
+    /// #[cfg(not(feature = "multichar"))]
     /// assert_eq!(hello.display().delimiter(';').to_string(), "[H; e; l; l; o]");
     /// ```
     pub fn delimiter(self, delimiter: ChromeLiteral) -> Self {
@@ -75,9 +75,9 @@ impl<'a, T: Display> SliceDisplayImpl<'a, T> {
     ///
     /// let hello: Vec<_> = "Hello".chars().collect();
     ///
-    /// #[cfg(not(feature = "multichar-chrome"))]
+    /// #[cfg(not(feature = "multichar"))]
     /// assert_eq!(hello.display().delimiter(';').to_string(), "[H; e; l; l; o]");
-    /// #[cfg(not(feature = "multichar-chrome"))]
+    /// #[cfg(not(feature = "multichar"))]
     /// assert_eq!(hello.display().delimiter(';').should_space(false).to_string(), "[H;e;l;l;o]");
     /// ```
     pub fn should_space(self, should_space: bool) -> Self {
@@ -95,13 +95,13 @@ where
     fn display(&self) -> SliceDisplayImpl<'_, T> {
         SliceDisplayImpl {
             slice: self.as_ref(),
-            #[cfg(feature = "multichar-chrome")]
+            #[cfg(feature = "multichar")]
             terminators: ("[", "]"),
-            #[cfg(not(feature = "multichar-chrome"))]
+            #[cfg(not(feature = "multichar"))]
             terminators: ('[', ']'),
-            #[cfg(feature = "multichar-chrome")]
+            #[cfg(feature = "multichar")]
             delimiter: ",",
-            #[cfg(not(feature = "multichar-chrome"))]
+            #[cfg(not(feature = "multichar"))]
             delimiter: ',',
             should_space: true,
         }
@@ -114,9 +114,9 @@ impl<'a, T: Display> Display for SliceDisplayImpl<'a, T> {
         let delimiter = self.delimiter;
         let spacing = if self.should_space { " " } else { "" };
 
-        #[cfg(feature = "multichar-chrome")]
+        #[cfg(feature = "multichar")]
         f.write_str(beginning)?;
-        #[cfg(not(feature = "multichar-chrome"))]
+        #[cfg(not(feature = "multichar"))]
         f.write_char(beginning)?;
 
         if let Some((last, elems)) = self.slice.split_last() {
@@ -126,10 +126,10 @@ impl<'a, T: Display> Display for SliceDisplayImpl<'a, T> {
             write!(f, "{last}")?;
         }
 
-        #[cfg(feature = "multichar-chrome")]
+        #[cfg(feature = "multichar")]
         return f.write_str(ending);
 
-        #[cfg(not(feature = "multichar-chrome"))]
+        #[cfg(not(feature = "multichar"))]
         f.write_char(ending)
     }
 }
@@ -168,7 +168,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "multichar-chrome"))]
+    #[cfg(not(feature = "multichar"))]
     fn slice_display_custom_delimiter() {
         let numbers = [1, 2, 3, 4, 5];
         assert_eq!(
@@ -186,7 +186,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "multichar-chrome"))]
+    #[cfg(not(feature = "multichar"))]
     fn slice_display_custom_terminators() {
         let numbers = [1, 2, 3, 4, 5];
         assert_eq!(
@@ -205,7 +205,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "multichar-chrome")]
+    #[cfg(feature = "multichar")]
     fn slice_display_custom_multichar_chrome() {
         let numbers = [1, 2, 3, 4, 5];
         assert_eq!(


### PR DESCRIPTION
The idea is just to have a feature that permits using hardcoded string literals instead of `char`s for the various display components representing the slice itself.

Status:
* Doc tests don't work; for some reason the `assert` statements are still present when the new feature is enabled, even with `#[cfg(not(...))]`. I'm guessing there's a fairly easy fix here, but I don't know what it is.
* I'm happy to change the name of the feature and/or the type alias to use a better word than "chrome"; I chose "chrome" for its association with browser UI elements as distinguished from the web content the browser displays.